### PR TITLE
Add a test case to verify that code inside the `defstyled` gets eval

### DIFF
--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -49,6 +49,11 @@
   {:color "green"
    :list-style :square})
 
+(def tokens {:main-color "green"})
+
+(o/defstyled with-code :div
+  {:background-color (-> tokens :main-color)})
+
 #?(:clj
    (deftest css-test
      (is (= ".ot__simple{color:#fff}"
@@ -70,7 +75,10 @@
             (o/css ornament-in-ornament)))
 
      (is (= ".ot__inherited{color:green;background-color:red;list-style:square}"
-            (o/css inherited)))))
+            (o/css inherited)))
+
+     (is (= ".ot__with_code{background-color:green}"
+            (o/css with-code)))))
 
 (deftest rendering-test
   (are [hiccup html] (= html (render hiccup))


### PR DESCRIPTION
Since this is a macro and we typically pass literals in there it's easy to get
in a situation where the forms passed to the macro are ending up quoted.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
