### PR TITLE
Provide more convenient access to Girouette config

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,7 @@
   girouette/girouette {:git/url   "https://github.com/green-coder/girouette.git"
                        :sha       "efcfea29e9744c475f3bace9a2843207b621801b"
                        :deps/root "lib/girouette"}
+  meta-merge/meta-merge {:mvn/version "1.0.0"}
 
   ;; Thicc
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.2"}

--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -9,7 +9,8 @@
                       [girouette.tw.core :as girouette]
                       [girouette.tw.typography :as girouette-typography]
                       [girouette.tw.color :as girouette-color]
-                      [girouette.tw.default-api :as girouette-default]])
+                      [girouette.tw.default-api :as girouette-default]
+                      [meta-merge.core :as meta-merge]])
             [lambdaisland.hiccup.protocols :refer [HiccupTag -expand]])
   #?(:cljs
      (:require-macros [lambdaisland.ornament :refer [defstyled]])))
@@ -38,13 +39,72 @@
   (tag [_])
   (component [_]))
 
+(declare process-rule)
+
 #?(:clj
    (do
-     (def girouette-api
-       (atom (girouette/make-api
-              girouette-default/default-components
-              {:color-map girouette-color/default-color-map
-               :font-family-map girouette-typography/default-font-family-map})))
+     (defonce girouette-api (atom nil))
+
+     (def default-tokens
+       {:components girouette-default/default-components
+        :colors     girouette-color/default-color-map
+        :fonts      girouette-typography/default-font-family-map})
+
+     (defn set-tokens!
+       "Set \"design tokens\": colors, fonts, and components
+
+        This configures Girouette, so that these tokens become available inside
+        Ornament style declarations.
+
+        - `:colors` : map from keyword to 6-digit hex color, without leading `#`
+        - `:fonts`: map from keyword to font stack (comman separated string)
+        - `:components`: sequence of Girouette components, each a map with
+          `:id` (keyword), `:rules` (string, instaparse, can be omitted), and
+          `:garden` (map, or function taking instaparse results and returning Garden
+          map)
+
+        If `:rules` is omitted we assume this is a static token, and we'll
+        generate a rule of the form `token-id = <'token-id'>`.
+
+        `:garden` can be a function, in which case it receives a map with a
+        `:compoent-data` key containing the instaparse parse tree. Literal maps or
+        vectors are wrapped in a function, in case the returned Garden is fixed. The
+        resulting Garden styles are processed again as in `defstyled`, so you can use
+        other Girouette or other tokens in there as well. Use `[:&]` for returning
+        multiple tokens/maps/stylesUse `[:&]` for returning multiple
+        tokens/maps/styles.
+
+        By default these are added to the Girouette defaults, use meta-merge
+        annotations (e.g. `{:colors ^:replace {...}}`) to change that behaviour."
+       [{:keys [components colors fonts]}]
+       (let [{:keys [components colors fonts]}
+             (meta-merge/meta-merge
+              default-tokens
+              {:components
+               (into (empty components)
+                     (map (fn [{:keys [id rules garden] :as c}]
+                            (cond-> c
+                              (not rules)
+                              (assoc :rules (str "\n" (name id) " = <'" (name id) "'>" "\n"))
+                              (not (fn? garden))
+                              (assoc :garden (constantly garden))
+
+                              :always
+                              (update :garden #(comp process-rule %)))))
+                     components)
+               :colors (into (empty colors)
+                             (map (juxt (comp name key) val))
+                             colors)
+               :fonts (into (empty fonts)
+                            (map (juxt (comp name key) val))
+                            fonts)})]
+         (reset! girouette-api
+                 (girouette/make-api
+                  components
+                  {:color-map colors
+                   :font-family-map fonts}))))
+
+     (defonce set-default-tokens (set-tokens! nil))
 
      (defn class-name->garden [n]
        ((:class-name->garden @girouette-api) n))
@@ -100,8 +160,6 @@
          (str/join sep val)
          val))
 
-     (declare process-rule)
-
      (defmulti process-tag (fn [[tag & _]] tag))
 
      (defmethod process-tag :default [v]
@@ -125,11 +183,11 @@
 
      (defmethod process-tag :at-supports [[_ feature-queries & rules]]
        (gt/->CSSAtRule :feature {:feature-queries feature-queries
-                                 :rules (into [:&] rules)}))
+                                 :rules           (into [:&] rules)}))
 
      (defmethod process-tag :at-keyframes [[_ identifier & frames]]
        (gt/->CSSAtRule :keyframes {:identifier identifier
-                                   :frames frames}))
+                                   :frames     frames}))
 
      (defmethod process-tag :rgb [[_ r g b]]
        (gcolor/rgb [r g b]))

--- a/test/lambdaisland/ornament_test.cljc
+++ b/test/lambdaisland/ornament_test.cljc
@@ -101,3 +101,94 @@
 
     [simple {:class [time]}]
     "<span class=\"ot__simple ot__time\"></span>"))
+
+(o/set-tokens! {:colors {:primary "001122"}
+                :fonts {:system "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji"}
+                :components [{:id :full-center
+                              :garden {:display "inline-flex"
+                                       :align-items "center"}}
+                             {:id :full-center-bis
+                              :garden [:& :inline-flex :items-center]}
+                             {:id :custom-bullets
+                              :rules "custom-bullets = <'bullets-'> bullet-char
+                                      <bullet-char> = #\".\""
+                              :garden (fn [{[bullet-char] :component-data}]
+                                        [:&
+                                         {:list-style "none"
+                                          :padding 0
+                                          :margin 0}
+                                         [:li
+                                          {:padding-left "1rem"
+                                           :text-indent "-0.7rem"}]
+                                         ["li::before"
+                                          {:content bullet-char}]])}]})
+
+(o/defstyled custok1 :div
+  :bg-primary)
+
+(o/defstyled custok2 :div
+  :font-system)
+
+(o/defstyled custok3 :div
+  :full-center)
+
+(o/defstyled custok4 :div
+  :full-center-bis)
+
+(o/defstyled custok5 :ul
+  :bullets-🐻)
+
+(deftest custom-tokens-test
+  (is (= ".ot__custok1{--gi-bg-opacity:1;background-color:rgba(0,17,34,var(--gi-bg-opacity))}"
+         (o/css custok1)))
+
+  (is (= ".ot__custok2{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji}"
+         (o/css custok2)))
+
+  (is (= ".ot__custok3{display:inline-flex;align-items:center}"
+         (o/css custok3)))
+
+  (is (= ".ot__custok4{display:inline-flex;align-items:center}"
+         (o/css custok4)))
+
+  (is (= ".ot__custok5{list-style:none;padding:0;margin:0}.ot__custok5 li{padding-left:1rem;text-indent:-0.7rem}.ot__custok5 li::before{content:🐻}"
+         (o/css custok5))))
+
+(deftest meta-merge-tokens-test
+  ;; establish baseline
+  (is (= {:--gi-bg-opacity 1, :background-color "rgba(239,68,68,var(--gi-bg-opacity))"}
+         (o/process-rule :bg-red-500)))
+
+  (is (= {:font-family "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"}
+         (o/process-rule :font-mono)))
+
+  (is (= {:border-radius "0.75rem"}
+         (o/process-rule :rounded-xl)))
+
+  ;; Replace the default colors/fonts, leave the components so we can still do bg-* or font-*
+  (o/set-tokens! {:colors ^:replace {:primary "001122"}
+                  :fonts ^:replace {:system "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji"}})
+
+  ;; The built-in ones are all gone
+  (is (nil? (o/process-rule :bg-red-500)))
+  (is (nil? (o/process-rule :font-mono)))
+
+  (is {:--gi-bg-opacity 1, :background-color "rgba(0,17,34,var(--gi-bg-opacity))"}
+      (o/process-rule :bg-primary))
+
+  (is {:font-family "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji"}
+      (o/process-rule :font-system))
+
+
+  ;; Replace the components
+  (o/set-tokens! {:components ^:replace [{:id :full-center
+                                          :garden {:display "inline-flex"
+                                                   :align-items "center"}}]})
+
+  (is (= {:display "inline-flex", :align-items "center"}
+         (o/process-rule :full-center)))
+
+  (is (nil? (o/process-rule :rounded-xl)))
+
+  ;; Reset to defaults
+  (o/set-tokens! {}))


### PR DESCRIPTION
Provide a `set-tokens!` functions for configuring custom fonts, colors, and
components.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
