### PR TITLE
support for girouette responsive rules

### DIFF
--- a/src/lambdaisland/ornament.cljc
+++ b/src/lambdaisland/ornament.cljc
@@ -226,7 +226,13 @@
          rule
 
          (simple-keyword? rule)
-         (second (class-name->garden (name rule)))
+         (let [girouette-garden (class-name->garden (name rule))]
+           (if (and (record? girouette-garden)
+                    (= (:identifier girouette-garden) :media))
+             (-> girouette-garden
+                 (update-in [:value :rules] (fn [rules]
+                                              (map #(into [:&] (rest %)) rules))))
+             (second girouette-garden)))
 
          (map? rule)
          (into {} (map (fn [[k v]] [k (process-property k v)])) rule)


### PR DESCRIPTION
Now `:md:bg-red-500` classes will be supported in styled components.

Example

```clojure
(defstyled tea :div
    :grid :grid-cols-1 :md:grid-cols-6)
```